### PR TITLE
Making JsonPath serializable

### DIFF
--- a/jsurfer-core/src/main/java/org/jsfr/json/filter/JsonPathFilter.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/filter/JsonPathFilter.java
@@ -28,10 +28,12 @@ import org.jsfr.json.PrimitiveHolder;
 import org.jsfr.json.path.JsonPath;
 import org.jsfr.json.provider.JsonProvider;
 
+import java.io.Serializable;
+
 /**
  * Created by Leo on 2017/4/4.
  */
-public interface JsonPathFilter {
+public interface JsonPathFilter extends Serializable {
 
     /**
      * Returns whether json position satisfies the filter.

--- a/jsurfer-core/src/main/java/org/jsfr/json/path/JsonPath.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/path/JsonPath.java
@@ -28,6 +28,7 @@ import org.jsfr.json.exception.JsonPathCompilerException;
 import org.jsfr.json.filter.JsonPathFilter;
 import org.jsfr.json.resolver.DocumentResolver;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -35,7 +36,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeMap;
 
-public class JsonPath implements Iterable<PathOperator> {
+public class JsonPath implements Iterable<PathOperator>, Serializable {
 
     private static final int JSON_PATH_INITIAL_CAPACITY = 20;
 

--- a/jsurfer-core/src/main/java/org/jsfr/json/path/PathOperator.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/path/PathOperator.java
@@ -27,7 +27,9 @@ package org.jsfr.json.path;
 import org.jsfr.json.resolver.DocumentResolver;
 import org.jsfr.json.resolver.Resolvable;
 
-public abstract class PathOperator implements Resolvable {
+import java.io.Serializable;
+
+public abstract class PathOperator implements Resolvable, Serializable {
 
     @SuppressWarnings("checkstyle:JavadocVariable")
     public enum Type {


### PR DESCRIPTION
Making JsonPath serializable so we could pre-compile it in constructor of ```com.hazelcast.jet.sql.impl.expression.json.JsonValueFunction```