### PR TITLE
Consider current depth in filter verifiers for primitives

### DIFF
--- a/jsurfer-all/src/test/java/org/jsfr/json/JsonSurferTest.java
+++ b/jsurfer-all/src/test/java/org/jsfr/json/JsonSurferTest.java
@@ -1181,6 +1181,24 @@ public abstract class JsonSurferTest<O extends P, A extends P, P> {
     }
 
     @Test
+    public void testNestedArraysAndFilters() throws IOException {
+        //given
+        Collector collector = surfer.collector(read("sample7.json"));
+        JsonPath path = JsonPathCompiler.compile("$.userRecords[*]?(@.eyeColor==\"blue\")");
+
+        //when
+        O providerObject = this.provider.createObject();
+        ValueBox<? extends Collection<?>> box1 = collector.collectAll(path, providerObject.getClass());
+        collector.exec();
+
+        //then
+        Collection<?> value = box1.get();
+        assertEquals(1, value.size());
+        assertEquals(this.provider.primitive("cd78f42f-591c-4a12-9a06-7d30a17869d5"),
+            resolveObject(value.iterator().next(), "guid"));
+    }
+
+    @Test
     public void testNestedArraysSecondLevelIndex() throws IOException {
         //given
         Collector collector = surfer.collector(read("nested_array.json"));

--- a/jsurfer-all/src/test/resources/sample7.json
+++ b/jsurfer-all/src/test/resources/sample7.json
@@ -1,0 +1,92 @@
+{
+  "userRecords": [
+    {
+      "_id": "620e2633b38e7324cabf6d04",
+      "index": 0,
+      "guid": "cd78f42f-591c-4a12-9a06-7d30a17869d5",
+      "isActive": false,
+      "balance": "$1,376.00",
+      "age": 40,
+      "eyeColor": "blue",
+      "name": "Viola Rojas",
+      "gender": "female",
+      "company": "GEEKKO",
+      "email": "violarojas@geekko.com",
+      "phone": "+1 (943) 505-3484",
+      "address": "550 Belvidere Street, Vienna, South Dakota, 8767",
+      "about": "Cupidatat in ut deserunt consequat ipsum nisi incididunt dolore. Reprehenderit anim exercitation voluptate id. Veniam reprehenderit cillum velit occaecat irure ullamco id excepteur adipisicing velit ex ad enim quis. Ipsum eu in deserunt nostrud exercitation aute elit elit officia nulla consectetur pariatur incididunt sit. Incididunt eiusmod aute sit incididunt anim qui nulla quis. Esse excepteur labore in laborum aliqua.\r\n",
+      "registered": "2015-09-03T11:36:59 -02:00",
+      "latitude": -87.427608,
+      "longitude": -7.667973,
+      "tags": [
+        "mollit",
+        "amet",
+        "consequat",
+        "sint",
+        "proident",
+        "voluptate",
+        "laborum"
+      ],
+      "friends": [
+        {
+          "id": 0,
+          "name": "Schroeder Navarro"
+        },
+        {
+          "id": 1,
+          "name": "Cox Carrillo"
+        },
+        {
+          "id": 2,
+          "name": "Carver Erickson"
+        }
+      ],
+      "greeting": "Hello, Viola Rojas! You have 4 unread messages.",
+      "favoriteFruit": "strawberry"
+    },
+    {
+      "_id": "620e263303ec215f5c7c64de",
+      "index": 1,
+      "guid": "6a5f94c8-95ec-4999-99b6-68e457703ea3",
+      "isActive": false,
+      "balance": "$1,630.25",
+      "age": 37,
+      "eyeColor": "black",
+      "name": "Ochoa Sargent",
+      "gender": "male",
+      "company": "QUALITEX",
+      "email": "ochoasargent@qualitex.com",
+      "phone": "+1 (846) 489-2751",
+      "address": "410 Paerdegat Avenue, Clara, Maryland, 4368",
+      "about": "Fugiat anim cupidatat consequat adipisicing cillum et non. Consectetur voluptate mollit quis aliqua sunt ullamco cillum adipisicing. Velit ex Lorem irure labore dolore. Qui sunt officia aliqua mollit qui sunt ullamco. Elit pariatur consectetur anim officia ad cillum deserunt.\r\n",
+      "registered": "2019-07-28T10:41:43 -02:00",
+      "latitude": 72.149158,
+      "longitude": 12.621864,
+      "tags": [
+        "quis",
+        "qui",
+        "aliquip",
+        "consectetur",
+        "pariatur",
+        "occaecat",
+        "voluptate"
+      ],
+      "friends": [
+        {
+          "id": 0,
+          "name": "Christina West"
+        },
+        {
+          "id": 1,
+          "name": "Eve Andrews"
+        },
+        {
+          "id": 2,
+          "name": "Silva Mathews"
+        }
+      ],
+      "greeting": "Hello, Ochoa Sargent! You have 6 unread messages.",
+      "favoriteFruit": "strawberry"
+    }
+  ]
+}

--- a/jsurfer-core/src/main/java/org/jsfr/json/ContentDispatcher.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/ContentDispatcher.java
@@ -29,7 +29,7 @@ import java.util.LinkedList;
 
 class ContentDispatcher implements JsonSaxHandler {
 
-    private LinkedList<JsonSaxHandler> receiver = new LinkedList<JsonSaxHandler>();
+    private final LinkedList<JsonSaxHandler> receiver = new LinkedList<JsonSaxHandler>();
 
     public boolean isEmpty() {
         return this.receiver.isEmpty();
@@ -154,9 +154,5 @@ class ContentDispatcher implements JsonSaxHandler {
     public void addReceiver(JsonSaxHandler contentHandler) {
         receiver.addFirst(contentHandler);
     }
-
-//    public JsonSaxHandler getLastReceiver() {
-//        return this.receiver.isEmpty() ? null : this.receiver.getFirst();
-//    }
 
 }

--- a/jsurfer-core/src/main/java/org/jsfr/json/FilterVerifierDispatcher.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/FilterVerifierDispatcher.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 public class FilterVerifierDispatcher extends ContentDispatcher {
 
-    private Map<SurfingConfiguration.Binding, JsonFilterVerifier> verifiers = new HashMap<>();
+    private final Map<SurfingConfiguration.Binding, JsonFilterVerifier> verifiers = new HashMap<>();
 
     public void addVerifier(SurfingConfiguration.Binding binding, JsonFilterVerifier verifier) {
         this.addReceiver(verifier);

--- a/jsurfer-core/src/main/java/org/jsfr/json/JsonFilterVerifier.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/JsonFilterVerifier.java
@@ -120,7 +120,7 @@ public class JsonFilterVerifier implements JsonSaxHandler {
         if (!this.verified && this.jsonPathFilter.apply(this.currentPosition, primitiveHolder, this.config.getJsonProvider())) {
             this.verified = true;
         }
-        if (this.currentPosition.isInsideArray()) {
+        if (this.stackDepth == 0 && this.currentPosition.isInsideArray()) {
             if (this.verified) {
                 this.invokeBuffer();
             }

--- a/jsurfer-core/src/main/java/org/jsfr/json/JsonPosition.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/JsonPosition.java
@@ -66,7 +66,7 @@ class JsonPosition extends JsonPath {
 
     boolean isInsideArray() {
         PathOperator last = peek();
-        return last instanceof ArrayIndex;
+        return last.getType() == PathOperator.Type.ARRAY;
     }
 
     private void popArray(PathOperator node) {

--- a/jsurfer-core/src/main/java/org/jsfr/json/SurfingConfiguration.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/SurfingConfiguration.java
@@ -35,8 +35,10 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.Map;
 
 import static org.jsfr.json.compiler.JsonPathCompiler.compile;
@@ -103,6 +105,26 @@ public class SurfingConfiguration {
 
         JsonPathListener[] getListeners() {
             return listeners;
+        }
+
+        LinkedList<JsonPathListener> sinkInto(LinkedList<JsonPathListener> listeners,
+            JsonFilterVerifier verifier) {
+            LinkedList<JsonPathListener> listenersToAdd = listeners == null ? new LinkedList<>() : listeners;
+            JsonPathListener[] bindingListeners = this.listeners;
+            for (JsonPathListener listener : bindingListeners) {
+                if (verifier != null) {
+                    listenersToAdd.add(verifier.addListener(listener));
+                } else {
+                    listenersToAdd.add(listener);
+                }
+            }
+            return listenersToAdd;
+        }
+
+        LinkedList<JsonPathListener> sinkInto(LinkedList<JsonPathListener> listeners) {
+            LinkedList<JsonPathListener> listenersToAdd = listeners == null ? new LinkedList<>() : listeners;
+            Collections.addAll(listenersToAdd, this.listeners);
+            return listenersToAdd;
         }
 
     }

--- a/jsurfer-core/src/main/java/org/jsfr/json/SurfingConfiguration.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/SurfingConfiguration.java
@@ -107,8 +107,7 @@ public class SurfingConfiguration {
             return listeners;
         }
 
-        LinkedList<JsonPathListener> sinkInto(LinkedList<JsonPathListener> listeners,
-            JsonFilterVerifier verifier) {
+        LinkedList<JsonPathListener> sinkInto(LinkedList<JsonPathListener> listeners, JsonFilterVerifier verifier) {
             LinkedList<JsonPathListener> listenersToAdd = listeners == null ? new LinkedList<>() : listeners;
             JsonPathListener[] bindingListeners = this.listeners;
             for (JsonPathListener listener : bindingListeners) {

--- a/jsurfer-core/src/main/java/org/jsfr/json/SurfingContext.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/SurfingContext.java
@@ -39,8 +39,9 @@ import java.util.Map;
 
 /**
  * Receives JSON reading events from input data JSON parser, matches and delegates those events to filters
- * verifier (if there filters registered in JSON path) and content dispatcher that does value collection.
- * SurfingContext is not thread-safe
+ * verifier (if there are filters registered in JSON path) and to content dispatcher that does value collection.
+ *
+ * SurfingContext is not thread-safe.
  */
 public class SurfingContext implements ParsingContext, JsonSaxHandler {
 
@@ -69,7 +70,7 @@ public class SurfingContext implements ParsingContext, JsonSaxHandler {
 
         if (config.hasFilter()) {
 
-            // skip matching if "skipOverlappedPath" is enable
+            // skip matching if "skipOverlappedPath" is enabled
             if (config.isSkipOverlappedPath() && dispatcher.size() > 1) {
                 return;
             }
@@ -88,7 +89,7 @@ public class SurfingContext implements ParsingContext, JsonSaxHandler {
             }
 
         } else {
-            // skip matching if "skipOverlappedPath" is enable
+            // skip matching if "skipOverlappedPath" is enabled
             if (config.isSkipOverlappedPath() && !dispatcher.isEmpty()) {
                 return;
             }

--- a/jsurfer-core/src/main/java/org/jsfr/json/path/FilterableChildNode.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/path/FilterableChildNode.java
@@ -18,7 +18,7 @@ public class FilterableChildNode extends ChildNode {
 
     @Override
     public boolean match(PathOperator pathOperator) {
-        //filters are bind and checked separately
+        //filters are bound and checked separately
         return super.match(pathOperator);
     }
 


### PR DESCRIPTION
In filter verifiers, current depth was not considered during the processing of primitives. It led to nested arrays overlapping with outer arrays which causes incorrect output results. 

Related to hazelcast/hazelcast#20761