### PR TITLE
Relax `children` operator to be able to match arrays

### DIFF
--- a/jsurfer-all/src/test/java/org/jsfr/json/JsonSurferTest.java
+++ b/jsurfer-all/src/test/java/org/jsfr/json/JsonSurferTest.java
@@ -1479,6 +1479,29 @@ public abstract class JsonSurferTest<O extends P, A extends P, P> {
         assertEquals(1, box1.get().size());
     }
 
+    @Test
+    public void testChildrenOperator() throws IOException {
+        //given
+        Collector collector = surfer.collector(read("sample.json"));
+        JsonPath path1 = JsonPathCompiler.compile(
+            "$.store[\"book\"]");
+        JsonPath path2 = JsonPathCompiler.compile(
+            "$.store[*][\"book\"]");
+        JsonPath path3 = JsonPathCompiler.compile(
+            "$.store[0].book[0][\"category\",\"author\"]");
+
+        //when
+        ValueBox<Collection<Object>> box1 = collector.collectAll(path1, Object.class);
+        ValueBox<Collection<Object>> box2 = collector.collectAll(path2, Object.class);
+        ValueBox<Collection<Object>> box3 = collector.collectAll(path3, Object.class);
+        collector.exec();
+
+        //then
+        assertEquals(4, box1.get().size());
+        assertEquals(4, box2.get().size());
+        assertEquals(asList("reference", "Nigel Rees"), box3.get());
+    }
+
     private Object json(String key, String value) {
         O object = this.provider.createObject();
         this.provider.put(object, key, this.provider.primitive(value));

--- a/jsurfer-core/src/main/java/org/jsfr/json/path/ChildrenNode.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/path/ChildrenNode.java
@@ -31,7 +31,7 @@ import java.util.HashSet;
  */
 public class ChildrenNode extends PathOperator {
 
-    private HashSet<String> children;
+    private final HashSet<String> children;
 
     public ChildrenNode(HashSet<String> children) {
         this.children = children;
@@ -39,8 +39,7 @@ public class ChildrenNode extends PathOperator {
 
     @Override
     public boolean match(PathOperator pathOperator) {
-        return super.match(pathOperator)
-            && pathOperator instanceof ChildNode && children.contains(((ChildNode) pathOperator).getKey());
+        return pathOperator instanceof ChildNode && children.contains(((ChildNode) pathOperator).getKey());
     }
 
     @Override


### PR DESCRIPTION
Children operator `....object["child1", "child2"]` could be matched only with objects, not arrays. Fixed by relaxing `match` function. The only requirement now is that the operator must have 'key' field.