### PR TITLE
Migrate JsonSurfer to new Maven Central [DI-632]

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -37,15 +37,16 @@ jobs:
 
       - name: Do the Deployment and related stuff
         run: |
-          mvn versions:set -B -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
+          mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
           git commit -am "Release ${{ github.event.inputs.release-version }}"
           git tag v${{ github.event.inputs.release-version }}
-          mvn clean install -B
-          mvn deploy -B -Prelease -DskipTests
-          mvn versions:set -B -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
+          mvn clean install
+          mvn deploy --activate-profiles release -DskipTests
+          mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
           git commit -am "Next version is ${{ github.event.inputs.next-snapshot-version }}"
           git push origin v${{ github.event.inputs.release-version }} master
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          MAVEN_ARGS: --batch-mode --no-transfer-progress

--- a/.github/workflows/push-snapshots.yaml
+++ b/.github/workflows/push-snapshots.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/push-snapshots.yaml
+++ b/.github/workflows/push-snapshots.yaml
@@ -31,11 +31,12 @@ jobs:
 
       - name: Publish to Apache Maven Central
         run: |
-          PROJECT_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          PROJECT_VERSION=$(mvn --quiet -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
           if [[ "$PROJECT_VERSION" == *-SNAPSHOT ]]; then
-            mvn --batch-mode -Prelease deploy
+            mvn --activate-profiles release deploy
           fi
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          MAVEN_ARGS: --batch-mode --no-transfer-progress

--- a/jsurfer-all/pom.xml
+++ b/jsurfer-all/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>jsurfer-all</name>
     <artifactId>jsurfer-all</artifactId>
 
     <build>

--- a/jsurfer-benchmark/pom.xml
+++ b/jsurfer-benchmark/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
+    <name>jsurfer-benchmark</name>
     <artifactId>jsurfer-benchmark</artifactId>
 
     <dependencies>

--- a/jsurfer-core/pom.xml
+++ b/jsurfer-core/pom.xml
@@ -40,8 +40,8 @@
                         <artifactId>maven-gpg-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/jsurfer-core/pom.xml
+++ b/jsurfer-core/pom.xml
@@ -10,6 +10,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <name>jsurfer-core</name>
     <artifactId>jsurfer-core</artifactId>
 
     <properties>

--- a/jsurfer-fastjson/pom.xml
+++ b/jsurfer-fastjson/pom.xml
@@ -35,8 +35,8 @@
                         <artifactId>maven-gpg-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/jsurfer-fastjson/pom.xml
+++ b/jsurfer-fastjson/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>jsurfer-fastjson</name>
     <artifactId>jsurfer-fastjson</artifactId>
 
     <profiles>

--- a/jsurfer-gson/pom.xml
+++ b/jsurfer-gson/pom.xml
@@ -35,8 +35,8 @@
                         <artifactId>maven-gpg-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/jsurfer-gson/pom.xml
+++ b/jsurfer-gson/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>jsurfer-gson</name>
     <artifactId>jsurfer-gson</artifactId>
 
     <profiles>

--- a/jsurfer-jackson-jr/pom.xml
+++ b/jsurfer-jackson-jr/pom.xml
@@ -35,8 +35,8 @@
                         <artifactId>maven-gpg-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/jsurfer-jackson-jr/pom.xml
+++ b/jsurfer-jackson-jr/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>jsurfer-jackson-jr</name>
     <artifactId>jsurfer-jackson-jr</artifactId>
 
     <profiles>

--- a/jsurfer-jackson/pom.xml
+++ b/jsurfer-jackson/pom.xml
@@ -35,8 +35,8 @@
                         <artifactId>maven-gpg-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/jsurfer-jackson/pom.xml
+++ b/jsurfer-jackson/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>jsurfer-jackson</name>
     <artifactId>jsurfer-jackson</artifactId>
 
     <profiles>

--- a/jsurfer-jsonsimple/pom.xml
+++ b/jsurfer-jsonsimple/pom.xml
@@ -35,8 +35,8 @@
                         <artifactId>maven-gpg-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/jsurfer-jsonsimple/pom.xml
+++ b/jsurfer-jsonsimple/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>jsurfer-jsonsimple</name>
     <artifactId>jsurfer-jsonsimple</artifactId>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <fastjson.version>1.2.79</fastjson.version>
         <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
         <maven.checkstyle.plugin.version>3.5.0</maven.checkstyle.plugin.version>
-        <nexus.staging.maven.plugin.version>1.7.0</nexus.staging.maven.plugin.version>
+        <central.publishing.maven..plugin.version>1.7.0</central.publishing.maven..plugin.version>
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.10.0</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>3.2.5</maven.gpg.plugin.version>
@@ -51,22 +51,11 @@
         </license>
     </licenses>
 
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <repositories>
         <repository>
             <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -82,14 +71,21 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus.staging.maven.plugin.version}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central.publishing.maven..plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <!-- server id comes from settings.xml -->
+                            <publishingServerId>ossrh</publishingServerId>
+                            <!--
+                            wait until the artifacts are actually published automatically using 'autoPublish'.
+                            the default is `validated` which would then require manual publishing
+                            -->
+                            <waitUntil>published</waitUntil>
+                            <autoPublish>true</autoPublish>
+                            <checksums>required</checksums>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <fastjson.version>1.2.79</fastjson.version>
         <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
         <maven.checkstyle.plugin.version>3.5.0</maven.checkstyle.plugin.version>
-        <central.publishing.maven..plugin.version>1.7.0</central.publishing.maven..plugin.version>
+        <central.publishing.maven..plugin.version>0.9.0</central.publishing.maven..plugin.version>
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.10.0</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>3.2.5</maven.gpg.plugin.version>


### PR DESCRIPTION
### Changes


- This is OSS only project so plugin deploys SNAPSHOT and release artifacts
- add  missing `<name>` in poms
- add `MAVEN_ARGS` in GH workflows plus `workflow_dispatch` in [push-snapshots.yaml](https://github.com/hazelcast/JsonSurfer/blob/master/.github/workflows/push-snapshots.yaml)


### Testing
#### Snapshot

Version: `0.13-SNAPSHOT`

- Ran [build](https://github.com/hazelcast/JsonSurfer/actions/runs/18127280150) on test branch
- Deployed successfully. Example [maven-metadata.xml](https://central.sonatype.com/repository/maven-snapshots/com/hazelcast/jsurfer/jsurfer-gson/0.13-SNAPSHOT/maven-metadata.xml)

#### Release

Version: `0.0.1`

Made changes on temp branch[diff](https://github.com/hazelcast/JsonSurfer/compare/JsonSurfer-new-portal...TEST-JsonSurfer-new-portal)

1. Ran build [successfully](https://github.com/hazelcast/JsonSurfer/actions/runs/18127522523)
2. Validated deployment available for publishing [here](https://central.sonatype.com/publishing/deployments)
3. <img width="1165" height="590" alt="image" src="https://github.com/user-attachments/assets/2d6043fa-b7cb-4dfd-8260-874a6b479d9a" />

### Post tasks

- [x] Remove staged deployment
- [x] Remove temp branches

Fixes [DI-632](https://hazelcast.atlassian.net/browse/DI-632)

[DI-632]: https://hazelcast.atlassian.net/browse/DI-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ